### PR TITLE
Implement authlogin endpoint

### DIFF
--- a/internal/handlers/user.handler.go
+++ b/internal/handlers/user.handler.go
@@ -85,3 +85,30 @@ func (uh *UserHandler) Register(ctx *gin.Context) {
 	})
 
 }
+
+func (uh *UserHandler) Login(ctx *gin.Context) {
+	var req models.LoginRequest
+	if err := ctx.BindJSON(&req); err != nil {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			if len(validationErrors) > 0 {
+				fe := validationErrors[0]
+				var params []string
+				switch fe.Tag() {
+				case "min", "max":
+					params = []string{fe.Param()}
+				}
+				msg := messages.ErrorMessage{
+					Field:   fe.Field(),
+					Message: messages.MessageForTag(fe.Tag(), params...),
+				}
+				ctx.JSON(http.StatusBadRequest, gin.H{"error": msg})
+				return
+			}
+		}
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": messages.InvalidJSONOrMissingFields})
+		return
+	}
+
+	
+}

--- a/internal/handlers/user.handler.go
+++ b/internal/handlers/user.handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/AkifhanIlgaz/hotel-booking-app/internal/services"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/errors"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/messages"
+	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/response"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/token"
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
@@ -37,51 +38,44 @@ func (uh *UserHandler) Register(ctx *gin.Context) {
 					params = []string{fe.Param()}
 				}
 				msg := messages.ErrorMessage{
-					Field:   fe.Field(),
 					Message: messages.MessageForTag(fe.Tag(), params...),
 				}
-				ctx.JSON(http.StatusBadRequest, gin.H{"error": msg})
+				response.WithError(ctx, http.StatusBadRequest, msg.Message, fe)
 				return
 			}
 		}
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": messages.InvalidJSONOrMissingFields})
+		response.WithError(ctx, http.StatusBadRequest, messages.InvalidJSONOrMissingFields, err)
 		return
 	}
 
 	id, err := uh.userService.RegisterUser(req)
 	if err != nil {
 		if errors.Is(err, errors.ErrEmailTaken) {
-			ctx.JSON(http.StatusConflict, gin.H{"error": messages.EmailAlreadyRegistered})
+			response.WithError(ctx, http.StatusConflict, messages.EmailAlreadyRegistered, err)
 			return
 		}
 
-		ctx.JSON(http.StatusInternalServerError, gin.H{
-			"error": messages.EmailAlreadyRegistered,
-		})
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return
 	}
 
+	// Todo: role enum
 	accessToken, err := uh.tokenManager.GenerateAccessToken(id.String(), "user")
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": messages.SomethingWentWrong})
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return
 	}
 
 	// TODO: Better error handling
 	refreshToken, err := uh.tokenManager.GenerateRefreshToken(id)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": messages.SomethingWentWrong})
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{
-		"status":  "success",
-		"error":   nil,
-		"message": "User registered successfully",
-		"payload": gin.H{
-			"access_token":  accessToken,
-			"refresh_token": refreshToken,
-		},
+	response.WithSuccess(ctx, http.StatusCreated, messages.SuccessfullyRegistered, gin.H{
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
 	})
 
 }
@@ -99,51 +93,46 @@ func (uh *UserHandler) Login(ctx *gin.Context) {
 					params = []string{fe.Param()}
 				}
 				msg := messages.ErrorMessage{
-					Field:   fe.Field(),
 					Message: messages.MessageForTag(fe.Tag(), params...),
 				}
-				ctx.JSON(http.StatusBadRequest, gin.H{"error": msg})
+				response.WithError(ctx, http.StatusBadRequest, msg.Message, fe)
 				return
 			}
 		}
-		ctx.JSON(http.StatusBadRequest, gin.H{"error": messages.InvalidJSONOrMissingFields})
+		response.WithError(ctx, http.StatusBadRequest, messages.InvalidJSONOrMissingFields, err)
 		return
 	}
 
 	user, err := uh.userService.AuthenticateUser(req)
 	if err != nil {
 		// Todo: Error constants
-		if errors.Is(err, errors.New("no user for email")) {
-			ctx.JSON(http.StatusNotFound, gin.H{"error": messages.UserNotFound})
+		if errors.Is(err, errors.ErrUserNotFound) {
+			response.WithError(ctx, http.StatusNotFound, messages.UserNotFound, err)
 			return
 		}
-		if errors.Is(err, errors.New("invalid password")) {
-			ctx.JSON(http.StatusUnauthorized, gin.H{"error": messages.InvalidPassword})
+		if errors.Is(err, errors.ErrWrongPassword) {
+			response.WithError(ctx, http.StatusUnauthorized, messages.WrongPassword, err)
 			return
 		}
 	}
 
 	accessToken, err := uh.tokenManager.GenerateAccessToken(user.Id.String(), "user")
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": messages.SomethingWentWrong})
+
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return
 	}
 
 	// TODO: Better error handling
 	refreshToken, err := uh.tokenManager.GenerateRefreshToken(user.Id)
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, gin.H{"error": messages.SomethingWentWrong})
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return
 	}
 
-	ctx.JSON(http.StatusOK, gin.H{
-		"status":  "success",
-		"error":   nil,
-		"message": "Logged in successfully",
-		"payload": gin.H{
-			"access_token":  accessToken,
-			"refresh_token": refreshToken,
-		},
+	response.WithSuccess(ctx, http.StatusOK, messages.SuccessfullyLoggedIn, gin.H{
+		"access_token":  accessToken,
+		"refresh_token": refreshToken,
 	})
 
 }

--- a/internal/handlers/user.handler.go
+++ b/internal/handlers/user.handler.go
@@ -66,7 +66,6 @@ func (uh *UserHandler) Register(ctx *gin.Context) {
 		return
 	}
 
-	// TODO: Better error handling
 	refreshToken, err := uh.tokenManager.GenerateRefreshToken(id)
 	if err != nil {
 		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
@@ -105,7 +104,6 @@ func (uh *UserHandler) Login(ctx *gin.Context) {
 
 	user, err := uh.userService.AuthenticateUser(req)
 	if err != nil {
-		// Todo: Error constants
 		if errors.Is(err, errors.ErrUserNotFound) {
 			response.WithError(ctx, http.StatusNotFound, messages.UserNotFound, err)
 			return
@@ -118,12 +116,10 @@ func (uh *UserHandler) Login(ctx *gin.Context) {
 
 	accessToken, err := uh.tokenManager.GenerateAccessToken(user.Id.String(), "user")
 	if err != nil {
-
 		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return
 	}
 
-	// TODO: Better error handling
 	refreshToken, err := uh.tokenManager.GenerateRefreshToken(user.Id)
 	if err != nil {
 		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)

--- a/internal/models/response.model.go
+++ b/internal/models/response.model.go
@@ -2,7 +2,7 @@ package models
 
 type Response struct {
 	Status  string
-	Message string
-	Error   string
+	Message string // user-friendly message
+	Error   string // developer-friendly message
 	Payload any
 }

--- a/internal/models/user.model.go
+++ b/internal/models/user.model.go
@@ -39,3 +39,8 @@ type RegistrationRequest struct {
 	Email    string `json:"email" binding:"required,email"`
 	Password string `json:"password" binding:"required,min=8"`
 }
+
+type LoginRequest struct {
+	Email    string `json:"email" binding:"required,email"`
+	Password string `json:"password" binding:"required,min=8"`
+}

--- a/internal/services/user.service.go
+++ b/internal/services/user.service.go
@@ -57,14 +57,14 @@ func (us *UserService) AuthenticateUser(loginReq models.LoginRequest) (*models.U
 
 	if err := us.db.QueryRow(queries.SelectUserByEmail, loginReq.Email).Scan(&user.Id, &user.Name, &user.Email, &user.PasswordHash, &user.Role, &user.CreatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, errors.New("no user for email")
+			return nil, errors.ErrUserNotFound
 		}
 		return nil, fmt.Errorf("register user: %w", err)
 	}
 
 	isPasswordTrue := utils.VerifyPassword(loginReq.Password, user.PasswordHash)
 	if !isPasswordTrue {
-		return nil, errors.New("invalid password")
+		return nil, errors.ErrWrongPassword
 	}
 
 	return &user, nil

--- a/migrations/queries/select_user_by_email.go
+++ b/migrations/queries/select_user_by_email.go
@@ -1,0 +1,7 @@
+package queries
+
+const SelectUserByEmail = `
+	SELECT *
+	FROM users
+	WHERE email = $1;
+	`

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -9,5 +9,7 @@ var (
 )
 
 var (
-	ErrEmailTaken = errors.New("email address is already taken")
+	ErrEmailTaken    = errors.New("email address is already taken")
+	ErrUserNotFound  = errors.New("user not found")
+	ErrWrongPassword = errors.New("wrong password")
 )

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -3,8 +3,9 @@ package errors
 import "errors"
 
 var (
-	As = errors.As
-	Is = errors.Is
+	As  = errors.As
+	Is  = errors.Is
+	New = errors.New
 )
 
 var (

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -1,9 +1,11 @@
 package messages
 
 const (
-	SomethingWentWrong         string = "Something went wrong."
-	InvalidJSONOrMissingFields string = "Invalid JSON format or missing fields."
-	EmailAlreadyRegistered     string = "This email address is already registered."
-	UserNotFound               string = "User not found."
-	InvalidPassword            string = "Invalid password."
+	SomethingWentWrong         string = "Bir şeyler ters gitti. Lütfen daha sonra tekrar deneyin."
+	InvalidJSONOrMissingFields string = "Gönderdiğiniz bilgiler eksik ya da geçersiz. Lütfen formu kontrol edin."
+	EmailAlreadyRegistered     string = "Bu e-posta adresi zaten kullanılıyor. Giriş yapmayı deneyin."
+	UserNotFound               string = "Böyle bir kullanıcı bulunamadı. Lütfen bilgilerinizi kontrol edin."
+	WrongPassword              string = "Şifre hatalı. Lütfen tekrar deneyin."
+	SuccessfullyRegistered     string = "Kayıt başarılı! Şimdi giriş yapabilirsiniz."
+	SuccessfullyLoggedIn       string = "Başarıyla giriş yaptınız."
 )

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -4,4 +4,6 @@ const (
 	SomethingWentWrong         string = "Something went wrong."
 	InvalidJSONOrMissingFields string = "Invalid JSON format or missing fields."
 	EmailAlreadyRegistered     string = "This email address is already registered."
+	UserNotFound               string = "User not found."
+	InvalidPassword            string = "Invalid password."
 )

--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -1,0 +1,23 @@
+package response
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+func WithSuccess(c *gin.Context, statusCode int, message string, payload any) {
+	c.JSON(statusCode, gin.H{
+		"status":  "success",
+		"error":   nil,
+		"message": message,
+		"payload": payload,
+	})
+}
+
+func WithError(c *gin.Context, statusCode int, message string, err error) {
+	c.JSON(statusCode, gin.H{
+		"status":  "error",
+		"error":   err.Error(),
+		"message": message,
+		"payload": nil,
+	})
+}

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -2,7 +2,9 @@ package utils
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 )
 
@@ -25,4 +27,9 @@ func RandString(n int) (string, error) {
 	}
 
 	return base64.URLEncoding.EncodeToString(bytes), nil
+}
+
+func HashRefreshToken(token string) string {
+	hashedBytes := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(hashedBytes[:])
 }

--- a/pkg/utils/password.go
+++ b/pkg/utils/password.go
@@ -1,8 +1,6 @@
 package utils
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 
 	"golang.org/x/crypto/bcrypt"
@@ -17,7 +15,6 @@ func HashPassword(password string) (string, error) {
 	return string(hashedBytes), nil
 }
 
-func HashRefreshToken(token string) string {
-	hashedBytes := sha256.Sum256([]byte(token))
-	return hex.EncodeToString(hashedBytes[:])
+func VerifyPassword(password, passwordHash string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(passwordHash), []byte(password)) == nil
 }


### PR DESCRIPTION
## 🔐 Login Endpoint Eklendi (`POST /auth/login`)

Bu PR, kullanıcıların e-posta ve şifre ile giriş yapmasını sağlayan `POST /auth/login` endpoint'ini ekler.

---

## ✅ Neler Yapıldı?
- `POST /auth/login` endpoint'i eklendi
- Kullanıcı veritabanında e-posta ile sorgulanıyor
- Şifre, hash karşılaştırması ile doğrulanıyor (bcrypt)
- Giriş başarılı olursa:
  - JWT access token ve refresh token üretiliyor
  - Refresh token veritabanına kaydediliyor (1 kullanıcı için 1 token)
  - Standart `response.WithSuccess` yapısıyla token'lar dönülüyor
- Hatalı bilgilerde uygun `response.WithError` mesajları gösteriliyor

---




## 📌 İlgili Issue
Closes #2 