### PR TITLE
Implement authforgot password endpoint

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -50,9 +50,9 @@ func main() {
 	router := server.Group("/api")
 
 	userService := services.NewUserService(db)
-	userHandler := handlers.NewUserHandler(userService, tokenManager)
+	authHandler := handlers.NewAuthHandler(userService, tokenManager)
 
-	routeManager := routes.NewManager(router, userHandler)
+	routeManager := routes.NewManager(router, authHandler)
 
 	routeManager.SetupRoutes()
 

--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AkifhanIlgaz/hotel-booking-app/internal/services"
 	"github.com/AkifhanIlgaz/hotel-booking-app/migrations"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/db"
+	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/mail"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/token"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -45,12 +46,16 @@ func main() {
 		log.Fatalf("failed to create token manager: %v", err)
 	}
 
+	mailManager := mail.NewManager(cfg.SMTP)
+
 	server := gin.Default()
 
 	router := server.Group("/api")
 
 	userService := services.NewUserService(db)
-	authHandler := handlers.NewAuthHandler(userService, tokenManager)
+	otpService := services.NewOTPService(db)
+
+	authHandler := handlers.NewAuthHandler(userService, otpService, tokenManager, mailManager)
 
 	routeManager := routes.NewManager(router, authHandler)
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,9 +30,17 @@ type TokenConfig struct {
 	RefreshTokenExpiresIn int    `mapstructure:"refresh_token_expires_in" validate:"required"` // days
 }
 
+type SMTPConfig struct {
+	Host     string `mapstructure:"host" validate:"required,hostname|ip"`
+	Port     int    `mapstructure:"port" validate:"required,min=1,max=65535"`
+	Username string `mapstructure:"username" validate:"required"`
+	Password string `mapstructure:"password" validate:"required"`
+}
+
 type Config struct {
 	Postgres PostgresConfig `mapstructure:"postgres"`
 	Token    TokenConfig    `mapstructure:"token"`
+	SMTP     SMTPConfig     `mapstructure:"smtp"`
 }
 
 func Load(mod string) (Config, error) {

--- a/go.mod
+++ b/go.mod
@@ -36,11 +36,13 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
+	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 )
 
 require (
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gin-contrib/cors v1.7.5
+	github.com/go-mail/mail/v2 v2.3.0
 	github.com/go-playground/validator/v10 v10.26.0
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/gin-contrib/sse v1.0.0 h1:y3bT1mUWUxDpW4JLQg/HnTqV4rozuW4tC9eFKTxYI9E
 github.com/gin-contrib/sse v1.0.0/go.mod h1:zNuFdwarAygJBht0NTKiSi3jRf6RbqeILZ9Sp6Slhe0=
 github.com/gin-gonic/gin v1.10.0 h1:nTuyha1TYqgedzytsKYqna+DfLos46nTv2ygFy86HFU=
 github.com/gin-gonic/gin v1.10.0/go.mod h1:4PMNQiOhvDRa013RKVbsiNwoyezlm2rm0uX/T7kzp5Y=
+github.com/go-mail/mail/v2 v2.3.0 h1:wha99yf2v3cpUzD1V9ujP404Jbw2uEvs+rBJybkdYcw=
+github.com/go-mail/mail/v2 v2.3.0/go.mod h1:oE2UK8qebZAjjV1ZYUpY7FPnbi/kIU53l1dmqPRb4go=
 github.com/go-playground/locales v0.14.1 h1:EWaQ/wswjilfKLTECiXz7Rh+3BjFhfDFKv/oXslEjJA=
 github.com/go-playground/locales v0.14.1/go.mod h1:hxrqLVvrK65+Rwrd5Fc6F2O76J/NuW9t0sjnWqG1slY=
 github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJnYK9S473LQFuzCbDbfSFY=
@@ -158,6 +160,8 @@ google.golang.org/protobuf v1.36.1 h1:yBPeRvTftaleIgM3PZ/WBIZ7XM/eEYAaEyCwvyjq/g
 google.golang.org/protobuf v1.36.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc h1:2gGKlE2+asNV9m7xrywl36YYNnBG5ZQ0r/BOOxqPpmk=
+gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc/go.mod h1:m7x9LTH6d71AHyAX77c9yqWCCa3UKHcVEj9y7hAtKDk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/handlers/user.handler.go
+++ b/internal/handlers/user.handler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/AkifhanIlgaz/hotel-booking-app/internal/models"
 	"github.com/AkifhanIlgaz/hotel-booking-app/internal/services"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/errors"
+	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/mail"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/messages"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/response"
 	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/token"
@@ -16,12 +17,16 @@ import (
 type AuthHandler struct {
 	userService  *services.UserService
 	tokenManager *token.Manager
+	otpService   *services.OTPService
+	mailManager  *mail.Manager
 }
 
-func NewAuthHandler(userService *services.UserService, tokenManager *token.Manager) *AuthHandler {
+func NewAuthHandler(userService *services.UserService, otpService *services.OTPService, tokenManager *token.Manager, mailManager *mail.Manager) *AuthHandler {
 	return &AuthHandler{
 		userService:  userService,
 		tokenManager: tokenManager,
+		otpService:   otpService,
+		mailManager:  mailManager,
 	}
 }
 
@@ -224,4 +229,109 @@ func (h *AuthHandler) Logout(ctx *gin.Context) {
 	response.WithSuccess(ctx, http.StatusOK, messages.SuccessfullyLoggedOut, nil)
 }
 
-func (h *AuthHandler) ForgotPassword(ctx *gin.Context) {}
+func (h *AuthHandler) ForgotPassword(ctx *gin.Context) {
+	var req models.OTPRequest
+	if err := ctx.BindJSON(&req); err != nil {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			if len(validationErrors) > 0 {
+				fe := validationErrors[0]
+				var params []string
+				switch fe.Tag() {
+				case "min", "max":
+					params = []string{fe.Param()}
+				}
+				msg := messages.ErrorMessage{
+					Message: messages.MessageForTag(fe.Tag(), params...),
+				}
+				response.WithError(ctx, http.StatusBadRequest, msg.Message, fe)
+				return
+			}
+		}
+		response.WithError(ctx, http.StatusBadRequest, messages.InvalidJSONOrMissingFields, err)
+		return
+	}
+
+	user, err := h.userService.GetUserByEmail(req.Email)
+	if err != nil {
+		if errors.Is(err, errors.ErrUserNotFound) {
+			response.WithError(ctx, http.StatusNotFound, messages.UserNotFound, err)
+			return
+		}
+
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
+		return
+	}
+
+	// Todo: Create OTP code for this email
+	otpCode, err := h.otpService.GenerateOTP(user.Id)
+	if err != nil {
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
+		return
+	}
+
+	// Todo: Send OTP code to mail
+	err = h.mailManager.ForgotPassword(req.Email, otpCode)
+	if err != nil {
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
+		return
+	}
+
+
+	
+
+}
+
+func (h *AuthHandler) VerifyOTP(ctx *gin.Context) {
+	var req models.OTPVerificationRequest
+	if err := ctx.BindJSON(&req); err != nil {
+		var validationErrors validator.ValidationErrors
+		if errors.As(err, &validationErrors) {
+			if len(validationErrors) > 0 {
+				fe := validationErrors[0]
+				var params []string
+				switch fe.Tag() {
+				case "min", "max":
+					params = []string{fe.Param()}
+				}
+				msg := messages.ErrorMessage{
+					Message: messages.MessageForTag(fe.Tag(), params...),
+				}
+				response.WithError(ctx, http.StatusBadRequest, msg.Message, fe)
+				return
+			}
+		}
+		response.WithError(ctx, http.StatusBadRequest, messages.InvalidJSONOrMissingFields, err)
+		return
+	}
+
+	valid, err := h.otpService.VerifyOTP(req.Email, req.OTP)
+	if err != nil {
+		switch {
+		case errors.Is(err, errors.ErrUserNotFound):
+			response.WithError(ctx, http.StatusNotFound, messages.UserNotFound, err)
+			return
+		case err.Error() == "invalid otp":
+			response.WithError(ctx, http.StatusUnauthorized, "Invalid OTP code", err)
+			return
+		case err.Error() == "otp expired":
+			response.WithError(ctx, http.StatusUnauthorized, "OTP code has expired", err)
+			return
+		case err.Error() == "otp already used":
+			response.WithError(ctx, http.StatusUnauthorized, "OTP code has already been used", err)
+			return
+		default:
+			response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
+			return
+		}
+	}
+
+	if !valid {
+		response.WithError(ctx, http.StatusUnauthorized, "Invalid OTP code", nil)
+		return
+	}
+
+	// If OTP is valid, you can proceed with the next step (e.g., password reset)
+	// For now, we'll just return a success message
+	response.WithSuccess(ctx, http.StatusOK, "OTP verified successfully", nil)
+}

--- a/internal/handlers/user.handler.go
+++ b/internal/handlers/user.handler.go
@@ -264,7 +264,7 @@ func (h *AuthHandler) ForgotPassword(ctx *gin.Context) {
 	}
 
 	// Todo: Create OTP code for this email
-	otpCode, err := h.otpService.GenerateOTP(user.Id)
+	otpCode, err := h.otpService.GenerateOTP(user.Email)
 	if err != nil {
 		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, err)
 		return

--- a/internal/handlers/user.handler.go
+++ b/internal/handlers/user.handler.go
@@ -277,9 +277,7 @@ func (h *AuthHandler) ForgotPassword(ctx *gin.Context) {
 		return
 	}
 
-
-	
-
+	response.WithSuccess(ctx, http.StatusOK, messages.SentOTPCode, nil)
 }
 
 func (h *AuthHandler) VerifyOTP(ctx *gin.Context) {
@@ -331,7 +329,21 @@ func (h *AuthHandler) VerifyOTP(ctx *gin.Context) {
 		return
 	}
 
+	// Generate JWT reset token to change password
+	resetToken, err := h.tokenManager.GenerateResetToken(req.Email)
+	if err != nil {
+		response.WithError(ctx, http.StatusInternalServerError, messages.SomethingWentWrong, nil)
+		return
+	}
+
 	// If OTP is valid, you can proceed with the next step (e.g., password reset)
 	// For now, we'll just return a success message
-	response.WithSuccess(ctx, http.StatusOK, "OTP verified successfully", nil)
+	response.WithSuccess(ctx, http.StatusOK, "OTP verified successfully", gin.H{
+		"reset_token": resetToken,
+	})
+}
+
+
+func (h *AuthHandler) ChangePassword( ctx *gin.Context) {
+	
 }

--- a/internal/models/otp.model.go
+++ b/internal/models/otp.model.go
@@ -8,8 +8,8 @@ import (
 
 type OTPToken struct {
 	Id        uuid.UUID
-	UserId    uuid.UUID
-	Token     string
+	Email     string
+	TokenHash string
 	ExpiresAt time.Time
 	CreatedAt time.Time
 }

--- a/internal/models/otp.model.go
+++ b/internal/models/otp.model.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type OTPToken struct {
+	Id        uuid.UUID
+	UserId    uuid.UUID
+	Token     string
+	ExpiresAt time.Time
+	CreatedAt time.Time
+	Used      bool
+}
+
+type OTPRequest struct {
+	Email string `json:"email" binding:"required,email"`
+}
+
+type OTPVerificationRequest struct {
+	Email string `json:"email" binding:"required,email"`
+	OTP   string `json:"otp" binding:"required,min=6,max=6"`
+}

--- a/internal/models/otp.model.go
+++ b/internal/models/otp.model.go
@@ -12,7 +12,6 @@ type OTPToken struct {
 	Token     string
 	ExpiresAt time.Time
 	CreatedAt time.Time
-	Used      bool
 }
 
 type OTPRequest struct {

--- a/internal/models/user.model.go
+++ b/internal/models/user.model.go
@@ -48,3 +48,8 @@ type LoginRequest struct {
 type RefreshRequest struct {
 	RefreshToken string `json:"refresh_token" binding:"required"`
 }
+
+type ChangePasswordRequest struct {
+	ResetToken string `json:"reset_token" binding:"required"`
+	Password   string `json:"password" binding:"required,min=8"`
+}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -28,9 +28,7 @@ func (m Manager) userRoutes() {
 		auth.POST("/register", m.authHandler.Register)
 		auth.POST("/logout", m.authHandler.Logout)
 		auth.POST("/refresh", m.authHandler.Refresh)
-
-		// Todo: Implement
 		auth.POST("/forgot-password", m.authHandler.ForgotPassword)
-
+		auth.POST("/verify-otp", m.authHandler.VerifyOTP)
 	}
 }

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -28,6 +28,8 @@ func (m Manager) userRoutes() {
 		auth.POST("/register", m.authHandler.Register)
 		auth.POST("/logout", m.authHandler.Logout)
 		auth.POST("/refresh", m.authHandler.Refresh)
+
+		auth.POST("/change-password", m.authHandler.ChangePassword)
 		auth.POST("/forgot-password", m.authHandler.ForgotPassword)
 		auth.POST("/verify-otp", m.authHandler.VerifyOTP)
 	}

--- a/internal/routes/routes.go
+++ b/internal/routes/routes.go
@@ -7,13 +7,13 @@ import (
 
 type Manager struct {
 	r           *gin.RouterGroup
-	userHandler *handlers.UserHandler
+	authHandler *handlers.AuthHandler
 }
 
-func NewManager(r *gin.RouterGroup, userHandler *handlers.UserHandler) *Manager {
+func NewManager(r *gin.RouterGroup, authHandler *handlers.AuthHandler) *Manager {
 	return &Manager{
 		r:           r,
-		userHandler: userHandler,
+		authHandler: authHandler,
 	}
 }
 
@@ -24,13 +24,13 @@ func (m *Manager) SetupRoutes() {
 func (m Manager) userRoutes() {
 	auth := m.r.Group("/auth")
 	{
-		auth.POST("/login", m.userHandler.Login)
-		auth.POST("/register", m.userHandler.Register)
-		auth.POST("/logout", m.userHandler.Logout)
-		auth.POST("/refresh", m.userHandler.Refresh)
+		auth.POST("/login", m.authHandler.Login)
+		auth.POST("/register", m.authHandler.Register)
+		auth.POST("/logout", m.authHandler.Logout)
+		auth.POST("/refresh", m.authHandler.Refresh)
 
 		// Todo: Implement
-		auth.POST("/forgot-password")
+		auth.POST("/forgot-password", m.authHandler.ForgotPassword)
 
 	}
 }

--- a/internal/services/otp.service.go
+++ b/internal/services/otp.service.go
@@ -1,0 +1,98 @@
+package services
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/AkifhanIlgaz/hotel-booking-app/internal/models"
+	"github.com/AkifhanIlgaz/hotel-booking-app/migrations/queries"
+	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/errors"
+	"github.com/AkifhanIlgaz/hotel-booking-app/pkg/utils"
+	"github.com/google/uuid"
+)
+
+type OTPService struct {
+	db *sql.DB
+}
+
+func NewOTPService(db *sql.DB) *OTPService {
+	return &OTPService{
+		db: db,
+	}
+}
+
+func (s *OTPService) GenerateOTP(userId uuid.UUID) (string, error) {
+	// Generate a 6-digit OTP
+	otp, err := utils.GenerateNumericOTP(6)
+	if err != nil {
+		return "", fmt.Errorf("generate otp: %w", err)
+	}
+
+	// Create OTP token record
+	id := uuid.New()
+	now := time.Now()
+	expiresAt := now.Add(2 * time.Minute) // OTP expires in 10 minutes
+
+	_, err = s.db.Exec(queries.InsertOTPToken,
+		id,
+		userId,
+		otp,
+		expiresAt,
+		now,
+		false,
+	)
+	if err != nil {
+		return "", fmt.Errorf("save otp token: %w", err)
+	}
+
+	return otp, nil
+}
+
+func (s *OTPService) VerifyOTP(email, otp string) (bool, error) {
+	var token models.OTPToken
+	var userId uuid.UUID
+
+	// First get the user ID from email
+	err := s.db.QueryRow(queries.SelectUserIdByEmail, email).Scan(&userId)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, errors.ErrUserNotFound
+		}
+		return false, fmt.Errorf("get user id: %w", err)
+	}
+
+	// Then verify the OTP
+	err = s.db.QueryRow(queries.SelectOTPToken, userId, otp).Scan(
+		&token.Id,
+		&token.UserId,
+		&token.Token,
+		&token.ExpiresAt,
+		&token.CreatedAt,
+		&token.Used,
+	)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, errors.New("invalid otp")
+		}
+		return false, fmt.Errorf("verify otp: %w", err)
+	}
+
+	// Check if OTP is expired
+	if time.Now().After(token.ExpiresAt) {
+		return false, errors.New("otp expired")
+	}
+
+	// Check if OTP is already used
+	if token.Used {
+		return false, errors.New("otp already used")
+	}
+
+	// Mark OTP as used
+	_, err = s.db.Exec(queries.MarkOTPAsUsed, token.Id)
+	if err != nil {
+		return false, fmt.Errorf("mark otp as used: %w", err)
+	}
+
+	return true, nil
+}

--- a/internal/services/user.service.go
+++ b/internal/services/user.service.go
@@ -82,3 +82,16 @@ func (us *UserService) GetUserByEmail(email string) (*models.User, error) {
 
 	return &user, nil
 }
+
+func (us *UserService) UpdatePassword(email, password string) error {
+	hashedPassword, err := utils.HashPassword(password)
+	if err != nil {
+		return fmt.Errorf("hash password: %w", err)
+	}
+
+	if _, err := us.db.Exec(queries.UpdateUserPasswordByEmail, hashedPassword, email); err != nil {
+		return fmt.Errorf("update user password: %w", err)
+	}
+
+	return nil
+}

--- a/internal/services/user.service.go
+++ b/internal/services/user.service.go
@@ -69,3 +69,16 @@ func (us *UserService) AuthenticateUser(loginReq models.LoginRequest) (*models.U
 
 	return &user, nil
 }
+
+func (us *UserService) GetUserByEmail(email string) (*models.User, error) {
+	var user models.User
+
+	if err := us.db.QueryRow(queries.SelectUserByEmail, email).Scan(&user.Id, &user.Name, &user.Email, &user.PasswordHash, &user.Role, &user.CreatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.ErrUserNotFound
+		}
+		return nil, fmt.Errorf("check is user exists: %w", err)
+	}
+
+	return &user, nil
+}

--- a/migrations/queries/insert_user.query.go
+++ b/migrations/queries/insert_user.query.go
@@ -14,6 +14,6 @@ const InsertUser = `
 
 const UpdateUserPasswordByEmail = `
 	UPDATE users
-	SET password_hash = $1,
+	SET password_hash = $1
 	WHERE email = $2;
 `

--- a/migrations/queries/insert_user.query.go
+++ b/migrations/queries/insert_user.query.go
@@ -11,3 +11,9 @@ const InsertUser = `
 			$6
 		)
 `
+
+const UpdateUserPasswordByEmail = `
+	UPDATE users
+	SET password_hash = $1,
+	WHERE email = $2
+`

--- a/migrations/queries/insert_user.query.go
+++ b/migrations/queries/insert_user.query.go
@@ -15,5 +15,5 @@ const InsertUser = `
 const UpdateUserPasswordByEmail = `
 	UPDATE users
 	SET password_hash = $1,
-	WHERE email = $2
+	WHERE email = $2;
 `

--- a/migrations/queries/otp.query.go
+++ b/migrations/queries/otp.query.go
@@ -1,7 +1,7 @@
 package queries
 
 const InsertOTPToken = `
-	INSERT INTO otp_tokens (id, user_id, token, expires_at, created_at)
+	INSERT INTO otp_tokens (id, email, token_hash, expires_at, created_at)
 		VALUES (
 			$1,
 			$2,
@@ -12,14 +12,14 @@ const InsertOTPToken = `
 `
 
 const SelectOTPToken = `
-	SELECT id, user_id, token, expires_at, created_at
+	SELECT id, email, token_hash, expires_at, created_at
 	FROM otp_tokens
-	WHERE user_id = $1 AND token = $2
+	WHERE email = $1 AND token_hash = $2
 `
 
 const DeleteOTPToken = `
 	DELETE FROM otp_tokens
-	WHERE token = $1
+	WHERE token_hash = $1
 `
 
 const SelectUserIdByEmail = `

--- a/migrations/queries/otp.query.go
+++ b/migrations/queries/otp.query.go
@@ -1,27 +1,25 @@
 package queries
 
 const InsertOTPToken = `
-	INSERT INTO otp_tokens (id, user_id, token, expires_at, created_at, used)
+	INSERT INTO otp_tokens (id, user_id, token, expires_at, created_at)
 		VALUES (
 			$1,
 			$2,
 			$3,
 			$4,
-			$5,
-			$6
+			$5
 		)
 `
 
 const SelectOTPToken = `
-	SELECT id, user_id, token, expires_at, created_at, used
+	SELECT id, user_id, token, expires_at, created_at
 	FROM otp_tokens
 	WHERE user_id = $1 AND token = $2
 `
 
-const MarkOTPAsUsed = `
-	UPDATE otp_tokens
-	SET used = true
-	WHERE id = $1
+const DeleteOTPToken = `
+	DELETE FROM otp_tokens
+	WHERE token = $1
 `
 
 const SelectUserIdByEmail = `

--- a/migrations/queries/otp.query.go
+++ b/migrations/queries/otp.query.go
@@ -1,0 +1,31 @@
+package queries
+
+const InsertOTPToken = `
+	INSERT INTO otp_tokens (id, user_id, token, expires_at, created_at, used)
+		VALUES (
+			$1,
+			$2,
+			$3,
+			$4,
+			$5,
+			$6
+		)
+`
+
+const SelectOTPToken = `
+	SELECT id, user_id, token, expires_at, created_at, used
+	FROM otp_tokens
+	WHERE user_id = $1 AND token = $2
+`
+
+const MarkOTPAsUsed = `
+	UPDATE otp_tokens
+	SET used = true
+	WHERE id = $1
+`
+
+const SelectUserIdByEmail = `
+	SELECT id
+	FROM users
+	WHERE email = $1
+`

--- a/migrations/schemas/schemas.go
+++ b/migrations/schemas/schemas.go
@@ -32,7 +32,6 @@ CREATE TABLE IF NOT EXISTS otp_tokens (
     token VARCHAR(6) NOT NULL,
     expires_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP NOT NULL,
-    used BOOLEAN NOT NULL DEFAULT false
 );
 
 CREATE INDEX IF NOT EXISTS idx_otp_tokens_user_id ON otp_tokens(user_id);

--- a/migrations/schemas/schemas.go
+++ b/migrations/schemas/schemas.go
@@ -1,7 +1,7 @@
 package schemas
 
 func All() []string {
-	return []string{refreshTokens, users}
+	return []string{refreshTokens, users, otpTokens}
 }
 
 const refreshTokens string = `
@@ -23,4 +23,18 @@ CREATE TABLE IF NOT EXISTS users (
     role VARCHAR(10) NOT NULL CHECK (role IN ('admin', 'user')),
     created_at TIMESTAMP NOT NULL
 );
+`
+
+const otpTokens string = `
+CREATE TABLE IF NOT EXISTS otp_tokens (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id),
+    token VARCHAR(6) NOT NULL,
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    used BOOLEAN NOT NULL DEFAULT false
+);
+
+CREATE INDEX IF NOT EXISTS idx_otp_tokens_user_id ON otp_tokens(user_id);
+CREATE INDEX IF NOT EXISTS idx_otp_tokens_token ON otp_tokens(token);
 `

--- a/migrations/schemas/schemas.go
+++ b/migrations/schemas/schemas.go
@@ -28,8 +28,8 @@ CREATE TABLE IF NOT EXISTS users (
 const otpTokens string = `
 CREATE TABLE IF NOT EXISTS otp_tokens (
     id UUID PRIMARY KEY,
-    user_id UUID NOT NULL REFERENCES users(id),
-    token VARCHAR(6) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE CHECK (email ~* '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'),
+    token_hash TEXT NOT NULL,
     expires_at TIMESTAMP NOT NULL,
     created_at TIMESTAMP NOT NULL
 );

--- a/migrations/schemas/schemas.go
+++ b/migrations/schemas/schemas.go
@@ -31,9 +31,6 @@ CREATE TABLE IF NOT EXISTS otp_tokens (
     user_id UUID NOT NULL REFERENCES users(id),
     token VARCHAR(6) NOT NULL,
     expires_at TIMESTAMP NOT NULL,
-    created_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL
 );
-
-CREATE INDEX IF NOT EXISTS idx_otp_tokens_user_id ON otp_tokens(user_id);
-CREATE INDEX IF NOT EXISTS idx_otp_tokens_token ON otp_tokens(token);
 `

--- a/pkg/mail/mail.go
+++ b/pkg/mail/mail.go
@@ -18,12 +18,12 @@ type Email struct {
 	HTML    string
 }
 
-type EmailManager struct {
+type Manager struct {
 	dialer mail.Dialer
 }
 
-func NewManager(config config.SMTPConfig) *EmailManager {
-	return &EmailManager{
+func NewManager(config config.SMTPConfig) *Manager {
+	return &Manager{
 		dialer: mail.Dialer{
 			Host:     config.Host,
 			Port:     config.Port,
@@ -33,7 +33,7 @@ func NewManager(config config.SMTPConfig) *EmailManager {
 	}
 }
 
-func (m *EmailManager) Send(email Email) error {
+func (m *Manager) Send(email Email) error {
 	msg := mail.NewMessage()
 
 	msg.SetHeader("To", email.To)
@@ -51,7 +51,7 @@ type resetEmailData struct {
 	OTP string
 }
 
-func (m *EmailManager) ForgotPassword(to, otp string) error {
+func (m *Manager) ForgotPassword(to, otp string) error {
 	tmpl, err := template.ParseFiles("templates/password_reset.html")
 	if err != nil {
 		return err

--- a/pkg/mail/mail.go
+++ b/pkg/mail/mail.go
@@ -1,0 +1,78 @@
+package mail
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+
+	"github.com/AkifhanIlgaz/hotel-booking-app/config"
+	"github.com/go-mail/mail/v2"
+)
+
+const sender = "support@vb10.com"
+
+type Email struct {
+	From    string
+	To      string
+	Subject string
+	HTML    string
+}
+
+type EmailManager struct {
+	dialer mail.Dialer
+}
+
+func NewManager(config config.SMTPConfig) *EmailManager {
+	return &EmailManager{
+		dialer: mail.Dialer{
+			Host:     config.Host,
+			Port:     config.Port,
+			Username: config.Username,
+			Password: config.Password,
+		},
+	}
+}
+
+func (m *EmailManager) Send(email Email) error {
+	msg := mail.NewMessage()
+
+	msg.SetHeader("To", email.To)
+	msg.SetHeader("From", sender)
+	msg.SetBody("text/html", email.HTML)
+
+	err := m.dialer.DialAndSend(msg)
+	if err != nil {
+		return fmt.Errorf("send: %w", err)
+	}
+	return nil
+}
+
+type resetEmailData struct {
+	OTP string
+}
+
+func (m *EmailManager) ForgotPassword(to, otp string) error {
+	tmpl, err := template.ParseFiles("templates/password_reset.html")
+	if err != nil {
+		return err
+	}
+
+	var body bytes.Buffer
+	err = tmpl.Execute(&body, resetEmailData{OTP: otp})
+	if err != nil {
+		return err
+	}
+
+	email := Email{
+		To:      to,
+		Subject: "Reset your password",
+		HTML:    body.String(),
+	}
+
+	err = m.Send(email)
+	if err != nil {
+		return fmt.Errorf("forgot password email: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -11,4 +11,5 @@ const (
 	SuccessfullyLoggedOut      string = "Logged out successfully."
 	TokenExpired               string = "Your session has expired. Please log in again."
 	TokenNotFound              string = "Token not found. Please log in again."
+	SentOTPCode                string = "Check your inbox! We’ve just sent you a code to reset your password."
 )

--- a/pkg/messages/messages.go
+++ b/pkg/messages/messages.go
@@ -12,4 +12,5 @@ const (
 	TokenExpired               string = "Your session has expired. Please log in again."
 	TokenNotFound              string = "Token not found. Please log in again."
 	SentOTPCode                string = "Check your inbox! We’ve just sent you a code to reset your password."
+	InvalidToken               string = "Invalid Token" // ! change
 )

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -82,7 +82,6 @@ func (m *Manager) GenerateAccessToken(userId, role string) (string, error) {
 }
 
 func (m *Manager) GenerateResetToken(email string) (string, error) {
-
 	now := time.Now()
 
 	claims := ResetClaims{
@@ -215,12 +214,12 @@ func (m *Manager) GenerateRefreshToken(uid uuid.UUID) (string, error) {
 		_, execErr = m.db.Exec(queries.InsertRefreshToken,
 			id,
 			uid,
-			utils.HashRefreshToken(token),
+			utils.Hash(token),
 			now,
 			expiry,
 		)
 	} else {
-		_, execErr = m.db.Exec(queries.UpdateRefreshToken, utils.HashRefreshToken(token), now, expiry, uid)
+		_, execErr = m.db.Exec(queries.UpdateRefreshToken, utils.Hash(token), now, expiry, uid)
 	}
 
 	if execErr != nil {
@@ -233,7 +232,7 @@ func (m *Manager) GenerateRefreshToken(uid uuid.UUID) (string, error) {
 func (m *Manager) ValidateRefreshToken(refreshToken string) (uuid.UUID, error) {
 	var token models.RefreshToken
 
-	err := m.db.QueryRow(queries.SelectRefreshToken, utils.HashRefreshToken(refreshToken)).Scan(&token.Id, &token.UserId, &token.TokenHash, &token.ExpiresAt, &token.CreatedAt)
+	err := m.db.QueryRow(queries.SelectRefreshToken, utils.Hash(refreshToken)).Scan(&token.Id, &token.UserId, &token.TokenHash, &token.ExpiresAt, &token.CreatedAt)
 	if err != nil {
 		// Todo: if sql.ErrNoRows return custom error
 		return uuid.Nil, fmt.Errorf("check refresh token is expired: %w", err)

--- a/pkg/utils/crypto.go
+++ b/pkg/utils/crypto.go
@@ -29,7 +29,7 @@ func RandString(n int) (string, error) {
 	return base64.URLEncoding.EncodeToString(bytes), nil
 }
 
-func HashRefreshToken(token string) string {
+func Hash(token string) string {
 	hashedBytes := sha256.Sum256([]byte(token))
 	return hex.EncodeToString(hashedBytes[:])
 }

--- a/pkg/utils/otp.go
+++ b/pkg/utils/otp.go
@@ -1,0 +1,25 @@
+package utils
+
+import (
+	"crypto/rand"
+	"fmt"
+	"math/big"
+)
+
+// GenerateNumericOTP generates a random numeric OTP of specified length
+func GenerateNumericOTP(length int) (string, error) {
+	if length <= 0 {
+		return "", fmt.Errorf("invalid length: %d", length)
+	}
+
+	otp := make([]byte, length)
+	for i := range length {
+		num, err := rand.Int(rand.Reader, big.NewInt(10))
+		if err != nil {
+			return "", fmt.Errorf("generate random number: %w", err)
+		}
+		otp[i] = byte(num.Int64() + '0')
+	}
+
+	return string(otp), nil
+}

--- a/templates/password_reset.html
+++ b/templates/password_reset.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Password Reset</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background-color: #f6f9fc;
+      color: #333;
+      padding: 20px;
+    }
+    .container {
+      background-color: #ffffff;
+      border-radius: 8px;
+      max-width: 600px;
+      margin: auto;
+      padding: 30px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+    }
+    .otp {
+      font-size: 24px;
+      font-weight: bold;
+      color: #007bff;
+      margin-top: 20px;
+    }
+    .footer {
+      margin-top: 30px;
+      font-size: 12px;
+      color: #888;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>Password Reset Request</h2>
+
+    <p>We received a request to reset your password. Use the one-time code below to proceed:</p>
+    
+    <div class="otp">{{.OTP}}</div>
+    
+    <p>This code will expire in a few minutes. If you didn’t request this, you can safely ignore this email.</p>
+    
+    <div class="footer">
+      This is an automated message. Please do not reply.
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
### 🔧 What’s Added

- `POST /auth/forgot-password` endpoint:
  - Accepts an email in the request body.
  - Checks if the user exists in the database.
  - Generates a 6-digit OTP code.
  - Stores the OTP in the database with expiration.
  - Sends the OTP to the user’s email address.
  - Verify OTP then generate reset token if OTP code is valid 